### PR TITLE
Allow setting Patroni failsafe mode

### DIFF
--- a/internal/patroni/config.go
+++ b/internal/patroni/config.go
@@ -190,6 +190,11 @@ func DynamicConfiguration(
 	root["ttl"] = *cluster.Spec.Patroni.LeaderLeaseDurationSeconds
 	root["loop_wait"] = *cluster.Spec.Patroni.SyncPeriodSeconds
 
+	// Set failsafe_mode if enabled
+	if cluster.Spec.Patroni.FailsafeMode != nil && *cluster.Spec.Patroni.FailsafeMode {
+		root["failsafe_mode"] = true
+	}
+
 	// Copy the "postgresql" section before making any changes.
 	postgresql := map[string]any{
 		// TODO(cbandy): explain this. requires an archive, perhaps.

--- a/pkg/apis/postgres-operator.crunchydata.com/v1beta1/patroni_types.go
+++ b/pkg/apis/postgres-operator.crunchydata.com/v1beta1/patroni_types.go
@@ -15,6 +15,13 @@ type PatroniSpec struct {
 	// +kubebuilder:validation:Type=object
 	DynamicConfiguration SchemalessObject `json:"dynamicConfiguration,omitempty"`
 
+	// FailsafeMode enables Patroni's failsafe mode which prevents any automated failovers.
+	// This is useful when performing dangerous operations like major version upgrades.
+	// More info: https://patroni.readthedocs.io/en/latest/dcs_failsafe_mode.html
+	// +optional
+	// +kubebuilder:default=false
+	FailsafeMode *bool `json:"failsafeMode,omitempty"`
+
 	// TTL of the cluster leader lock. "Think of it as the
 	// length of time before initiation of the automatic failover process."
 	// Changing this value causes PostgreSQL to restart.


### PR DESCRIPTION
The existing CRD does not allow setting Patroni dynamic configuration options. This change allows setting the one we care about: failsafe mode.