### PR TITLE
ubuntu latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone the code
         uses: actions/checkout@v4


### PR DESCRIPTION
tests are broken because they can't run on that ubuntu any more so we're hiding tests from ourselves.