### PR TITLE
Jphenow/permit root

### DIFF
--- a/internal/initialize/security.go
+++ b/internal/initialize/security.go
@@ -39,7 +39,7 @@ func RestrictedSecurityContext(enableSeccompProfile bool) *corev1.SecurityContex
 		ReadOnlyRootFilesystem: Bool(true),
 
 		// Fail to start the container if its image runs as UID 0 (root).
-		RunAsNonRoot: Bool(true),
+		RunAsNonRoot: Bool(false),
 	}
 
 	if enableSeccompProfile {


### PR DESCRIPTION
ok, I think I have an image that will work but we need to boot as root and entrypoint adjusts to user 26.

this is preventing that.

possibly better option is probably to add a config option that uses the base image rather than this image to do postgres-startup then leave security constraints on. 

https://github.com/superfly/ui-ex/pull/3671
https://github.com/superfly/mpg-postgres-image

I haven't been able to boot it locally yet so this might not be everything but it's close 

---

Was #9 until I deleted the upstream which prevents me from updating the PR base and closes the PR.