### PR TITLE
fix: runs entrypoint-wrapper.sh when possible

### DIFF
--- a/internal/patroni/reconcile.go
+++ b/internal/patroni/reconcile.go
@@ -104,7 +104,14 @@ func InstancePod(ctx context.Context,
 		}
 	}
 
-	container.Command = []string{"patroni", configDirectory}
+	// Use entrypoint wrapper if available (indicated by version file), otherwise run patroni directly.
+	// The wrapper starts the OOM adjuster and shared memory cleanup before exec'ing to patroni.
+	// Ref: https://github.com/superfly/mpg-postgres-image/pull/3
+	container.Command = []string{
+		"sh", "-c",
+		`[ -f /usr/local/bin/.entrypoint-wrapper-version ] && exec /usr/local/bin/entrypoint-wrapper.sh "$@" || exec "$@"`,
+		"--", "patroni", configDirectory,
+	}
 
 	container.Env = append(container.Env,
 		instanceEnvironment(inCluster, inClusterPodService, inPatroniLeaderService,


### PR DESCRIPTION
The current command param overrides the container entrypoint, so our
wrapper never runs. Additionally, the wrapper itself needed a small fix
to both ignore the original entrypoint file (no longer present) and to
accept params .

To make this backwards compatible, we first check if our entrypoint can
run (via a version file). If so, we use it as entrypoint for the patroni
binary. Otherwise, we execute patroni directly (previous behavior).

Signed-off-by: Juliana Oliveira <juliana@fly.io>
