### PR TITLE
fix(backups): add flag to globally disable operator's automated backups

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,19 @@ func defaultFromEnv(value, key string) string {
 	return value
 }
 
+// AutomatedBackupsDisabled reports whether operator-driven pgBackRest backups
+// (manual, scheduled, and replica-create) are disabled cluster-wide via the
+// DISABLE_AUTOMATED_BACKUPS=true environment variable.
+//
+// When disabled, the operator still provisions all backup infrastructure (the
+// dedicated repo host, stanza, pgBackRest config and TLS secrets) so that
+// backups can be triggered manually against pgBackRest directly. Replicas
+// bootstrap via pg_basebackup, since pgBackRest is only offered as a Patroni
+// replica-create method once a replica-create backup has completed.
+func AutomatedBackupsDisabled() bool {
+	return os.Getenv("DISABLE_AUTOMATED_BACKUPS") == "true"
+}
+
 // FetchKeyCommand returns the fetch_key_cmd value stored in the encryption_key_command
 // variable used to enable TDE.
 func FetchKeyCommand(spec *v1beta1.PostgresClusterSpec) string {

--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -1627,6 +1627,19 @@ func (r *Reconciler) reconcilePGBackRest(ctx context.Context,
 		}
 	}
 
+	// K8SPG/Fly: When automated backups are disabled, the operator still
+	// provisions all backup infrastructure above (repo host, stanza, config and
+	// TLS secrets) but never creates backup Jobs or CronJobs itself. Backups are
+	// expected to be triggered manually against pgBackRest, and replicas
+	// bootstrap via pg_basebackup (pgBackRest is only offered as a Patroni
+	// replica-create method once a replica-create backup has completed, which
+	// never happens here). See config.AutomatedBackupsDisabled.
+	if config.AutomatedBackupsDisabled() {
+		log.V(1).Info("automated backups disabled; skipping scheduled, replica-create and manual backups",
+			"cluster", postgresCluster.Name)
+		return result, nil
+	}
+
 	// reconcile the pgBackRest backup CronJobs
 	requeue := r.reconcileScheduledBackups(ctx, postgresCluster, sa, repoResources.cronjobs)
 	// If the pgBackRest backup CronJob reconciliation function has encountered an error, requeue

--- a/internal/pgbackrest/reconcile.go
+++ b/internal/pgbackrest/reconcile.go
@@ -486,6 +486,20 @@ func ReplicaCreateCommand(
 		}
 	}
 
+	// When automated backups are disabled, the operator never runs a
+	// replica-create backup, so ReplicaCreateBackupComplete is never set above.
+	// Still offer pgBackRest as the preferred replica-create method against the
+	// replica-create repo (index 0). Patroni tries this first and automatically
+	// falls back to pg_basebackup when the command fails, e.g. right after the
+	// cluster is created and no backup exists yet. Once backups are taken
+	// manually, NEW replicas restore from the repository instead of streaming a
+	// full copy from the primary. See config.AutomatedBackupsDisabled.
+	//
+	// Ref.: https://patroni.readthedocs.io/en/latest/replica_bootstrap.html#building-replicas
+	if config.AutomatedBackupsDisabled() && len(cluster.Spec.Backups.PGBackRest.Repos) > 0 {
+		return command(cluster.Spec.Backups.PGBackRest.Repos[0].Name)
+	}
+
 	return nil
 }
 

--- a/percona/controller/pgbackup/controller.go
+++ b/percona/controller/pgbackup/controller.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/percona/percona-postgresql-operator/internal/config"
 	"github.com/percona/percona-postgresql-operator/internal/logging"
 	"github.com/percona/percona-postgresql-operator/internal/naming"
 	"github.com/percona/percona-postgresql-operator/percona/clientcmd"
@@ -87,6 +88,35 @@ func (r *PGBackupReconciler) Reconcile(ctx context.Context, request reconcile.Re
 			return reconcile.Result{}, errors.Wrap(err, "failed to run finalizers")
 		}
 		return reconcile.Result{RequeueAfter: requeueTimeout}, nil
+	}
+
+	// When automated backups are disabled cluster-wide, the operator never
+	// creates pgBackRest backup Jobs. Fail any pending PerconaPGBackup with a
+	// clear log message instead of leaving it to hang waiting for a Job that
+	// will never be created. Backups must be triggered manually against
+	// pgBackRest directly. See config.AutomatedBackupsDisabled.
+	if config.AutomatedBackupsDisabled() &&
+		pgBackup.Status.State != v2.BackupFailed && pgBackup.Status.State != v2.BackupSucceeded {
+		log.Info("automated backups are disabled (DISABLE_AUTOMATED_BACKUPS=true); "+
+			"not running operator-managed backup. Trigger pgBackRest backups manually.",
+			"pg-backup", pgBackup.Name)
+
+		rerr := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+			bcp := new(v2.PerconaPGBackup)
+
+			if err := r.Client.Get(ctx, client.ObjectKeyFromObject(pgBackup), bcp); err != nil {
+				return errors.Wrap(err, "get PGBackup")
+			}
+
+			bcp.Status.State = v2.BackupFailed
+			return r.Client.Status().Update(ctx, bcp)
+		})
+
+		if rerr != nil {
+			return reconcile.Result{}, errors.Wrap(rerr, "update PGBackup status")
+		}
+
+		return reconcile.Result{}, nil
 	}
 
 	if pgBackup.Status.State != v2.BackupFailed && pgBackup.Status.State != v2.BackupSucceeded {

--- a/percona/controller/pgcluster/controller.go
+++ b/percona/controller/pgcluster/controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/percona/percona-postgresql-operator/internal/config"
 	"github.com/percona/percona-postgresql-operator/internal/controller/runtime"
 	"github.com/percona/percona-postgresql-operator/internal/logging"
 	"github.com/percona/percona-postgresql-operator/internal/naming"
@@ -279,8 +280,13 @@ func (r *PGClusterReconciler) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, errors.Wrap(err, "reconcile custom extensions")
 	}
 
-	if err := r.reconcileScheduledBackups(ctx, cr); err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "reconcile scheduled backups")
+	// When automated backups are disabled cluster-wide, the operator does not
+	// register scheduled backup cron jobs. Backups are triggered manually
+	// against pgBackRest directly. See config.AutomatedBackupsDisabled.
+	if !config.AutomatedBackupsDisabled() {
+		if err := r.reconcileScheduledBackups(ctx, cr); err != nil {
+			return reconcile.Result{}, errors.Wrap(err, "reconcile scheduled backups")
+		}
 	}
 
 	if cr.Spec.Pause != nil && *cr.Spec.Pause {


### PR DESCRIPTION
This patch introduces DISABLE_AUTOMATED_BACKUPS. When true, the operator
will not trigger automated backups and current active backups will
default to failed state.

Signed-off-by: Juliana Oliveira <juliana@fly.io>
