### PR TITLE
fix(restore): add oidc container as sidecar

### DIFF
--- a/internal/controller/postgrescluster/pgbackrest.go
+++ b/internal/controller/postgrescluster/pgbackrest.go
@@ -1437,27 +1437,31 @@ func (r *Reconciler) generateRestoreJobIntent(cluster *v1beta1.PostgresCluster,
 		job.Spec.Template.Spec.InitContainers = append(job.Spec.Template.Spec.InitContainers, initContainers...)
 	}
 
-	// Add sidecars from RepoHost.Containers to the restore job
-	// if repoHost != nil && repoHost.EnvFromSecret != nil && repoHost.Containers != nil {
-	// 	containers := make([]corev1.Container, 0, len(repoHost.Containers))
+	if repoHost != nil && repoHost.EnvFromSecret != nil && repoHost.Containers != nil {
+		sidecars := make([]corev1.Container, 0, len(repoHost.Containers))
 
-	// 	// Add the envFrom reference to each sidecar container
-	// 	for _, c := range repoHost.Containers {
-	// 		envFrom := corev1.EnvFromSource{
-	// 			SecretRef: &corev1.SecretEnvSource{
-	// 				LocalObjectReference: corev1.LocalObjectReference{
-	// 					Name: *repoHost.EnvFromSecret,
-	// 				},
-	// 			},
-	// 		}
-	// 		c.EnvFrom = append(c.EnvFrom, envFrom)
+		// Add the envFrom reference to each sidecar container and mark it as a
+		// native sidecar so it runs alongside, not sequentially before, the
+		// rest of the pod.
+		for _, c := range repoHost.Containers {
+			envFrom := corev1.EnvFromSource{
+				SecretRef: &corev1.SecretEnvSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: *repoHost.EnvFromSecret,
+					},
+				},
+			}
+			c.EnvFrom = append(c.EnvFrom, envFrom)
+			c.RestartPolicy = initialize.Pointer(corev1.ContainerRestartPolicyAlways)
 
-	// 		containers = append(containers, c)
-	// 	}
+			sidecars = append(sidecars, c)
+		}
 
-	// 	// Add the sidecars to the job's containers
-	// 	job.Spec.Template.Spec.Containers = append(job.Spec.Template.Spec.Containers, containers...)
-	// }
+		// Sidecars must be started before the one-shot init containers and the
+		// main container so that credentials they provide are available to
+		// both, so they are prepended rather than appended.
+		job.Spec.Template.Spec.InitContainers = append(sidecars, job.Spec.Template.Spec.InitContainers...)
+	}
 
 	// Set the image pull secrets, if any exist.
 	// This is set here rather than using the service account due to the lack

--- a/internal/controller/postgrescluster/pgbackrest_test.go
+++ b/internal/controller/postgrescluster/pgbackrest_test.go
@@ -3031,6 +3031,67 @@ func TestGenerateRestoreJobIntent(t *testing.T) {
 	}
 }
 
+func TestGenerateRestoreJobIntentCustomSidecars(t *testing.T) {
+	_, cc := setupKubernetes(t)
+	require.ParallelCapacity(t, 0)
+
+	r := Reconciler{Client: cc}
+
+	secretName := "my-pgbackrest-env-secret" // #nosec G101
+	cluster := &v1beta1.PostgresCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test",
+			Labels: map[string]string{naming.LabelVersion: "2.5.0"},
+		},
+		Spec: v1beta1.PostgresClusterSpec{
+			Backups: v1beta1.Backups{
+				PGBackRest: v1beta1.PGBackRestArchive{
+					RepoHost: &v1beta1.PGBackRestRepoHost{
+						EnvFromSecret: &secretName,
+						InitContainers: []corev1.Container{
+							{Name: "one-shot-init"},
+						},
+						Containers: []corev1.Container{
+							{Name: "credential-refresher"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	job := &batchv1.Job{}
+	err := r.generateRestoreJobIntent(cluster, "", "",
+		[]string{}, []corev1.VolumeMount{}, []corev1.Volume{},
+		&v1beta1.PostgresClusterDataSource{}, job)
+	assert.NilError(t, err)
+
+	initContainers := job.Spec.Template.Spec.InitContainers
+	if assert.Check(t, len(initContainers) == 2, "expected 2 init containers, got %d", len(initContainers)) {
+		// The sidecar-turned-init-container must come first so credentials it
+		// provides are available to the one-shot init container that follows.
+		sidecar := initContainers[0]
+		assert.Equal(t, sidecar.Name, "credential-refresher")
+		if assert.Check(t, sidecar.RestartPolicy != nil, "expected sidecar RestartPolicy to be set") {
+			assert.Equal(t, *sidecar.RestartPolicy, corev1.ContainerRestartPolicyAlways)
+		}
+		if assert.Check(t, len(sidecar.EnvFrom) == 1) {
+			assert.Equal(t, sidecar.EnvFrom[0].SecretRef.Name, secretName)
+		}
+
+		oneShot := initContainers[1]
+		assert.Equal(t, oneShot.Name, "one-shot-init")
+		assert.Assert(t, oneShot.RestartPolicy == nil,
+			"one-shot init containers must not be marked as native sidecars")
+		if assert.Check(t, len(oneShot.EnvFrom) == 1) {
+			assert.Equal(t, oneShot.EnvFrom[0].SecretRef.Name, secretName)
+		}
+	}
+
+	// The main restore container is unaffected.
+	assert.Assert(t, len(job.Spec.Template.Spec.Containers) == 1)
+}
+
 func TestObserveRestoreEnv(t *testing.T) {
 	ctx := context.Background()
 	_, tClient := setupKubernetes(t)


### PR DESCRIPTION
Fixes a problem where a big restore would outlive the credential
lifetime (1h). Now credentials will be renewed automatically.

Signed-off-by: Juliana Oliveira <juliana@fly.io>
